### PR TITLE
Removed inline styling from table and added it to tink-core in branch…

### DIFF
--- a/src/templates/tinkDatePickerField.html
+++ b/src/templates/tinkDatePickerField.html
@@ -1,5 +1,5 @@
 <div role="datepicker" class="dropdown-menu datepicker" data-ng-class="{'aligns-right': $alignsright == 'true'}">
-  <table style="table-layout: fixed; height: 100%; width: 100%;">
+  <table>
     <thead>
       <tr class="text-center datepicker-nav">
         <th>
@@ -23,7 +23,7 @@
     <tbody>
       <tr data-ng-repeat="(i, row) in rows" height="{{ 100 / rows.length }}%">
         <td class="text-center" data-ng-repeat="(j, el) in row">
-          <button tabindex="0" type="button" class="btn" style="width: 100%" data-ng-class="{'btn-selected': el.selected, 'btn-today': el.isToday && !el.elected, 'btn-grayed':el.isMuted}" data-ng-mousedown="$disable($event)" data-ng-focus="elemFocus($event)" data-ng-click="$select(el.date)" data-ng-disabled="el.disabled">
+          <button tabindex="0" type="button" class="btn" data-ng-class="{'btn-selected': el.selected, 'btn-today': el.isToday && !el.elected, 'btn-grayed':el.isMuted}" data-ng-mousedown="$disable($event)" data-ng-focus="elemFocus($event)" data-ng-click="$select(el.date)" data-ng-disabled="el.disabled">
             <span role="" data-ng-class="{'text-muted': el.muted}" data-ng-bind="el.label"></span>
           </button>
         </td>


### PR DESCRIPTION
… inline-css-datepicker.

Removed inline styling from button since "width: 100%" is already defined in the .btn class.